### PR TITLE
Add background gradient shader with glsl and love

### DIFF
--- a/src/common.lua
+++ b/src/common.lua
@@ -46,7 +46,7 @@ M.Color = {
         -- GREENNNNN
         background = ({ { 0.06, 0.36, 0.30 }, { 0.4, 0.4, 0.4 }, { 0.75, 0.75, 0.75 } })[config.CURRENT_THEME], -- exposure: 0.0625, decay: 0.60
         -- creature_healed = { 0.45, 0.52, 0.45 }, -- before impl gradient bg shader
-        creature_healed = { 0.05, 0.02, 0.15, 0.4 },  -- after impl gradient bg shader
+        creature_healed = { 0.08, 0.08, 0.08, 0.2 },  -- after impl gradient bg shader
         creature_infected = ({ { 0.05, 0.02, 0.15 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME], -- green low_light
 
         -- BLUUEUUEUE
@@ -59,7 +59,8 @@ M.Color = {
 
         player_beserker_dash_modifier = { 0.9, 0.9, 0.4 }, --- ??? Chaos when shift + x are down. (yellow)
         player_beserker_modifier = { 135 / 255, 280 / 255, 138 / 255 }, --- buttercup Enhanced abilities, when either of shift key is pressed. (green)
-        player_dash_neonblue_modifier = { 0.8, 0.8, 1.0 }, --- bubbles (luminiscent blue)
+        -- player_dash_neonblue_modifier = { 0.8, 0.8, 1.0 }, --- bubbles (luminiscent blue)
+        player_dash_neonblue_modifier = { 0.85, 0.85, 0.95 }, --- bubbles (luminiscent blue)
         player_dash_pink_modifier = { 0.95, 0.4, 0.6 }, --- blossom The idle tail and projectile color. (purple)
         player_dash_yellow_modifier = { 0.9, 0.9, 0.4 }, --- You see, you're not dealing with the average player. (yellow)
         player_entity = ({ { 0.05 * 1, 0.05 * 1, 0.05 * 1 }, { 0.05 * 2, 0.05 * 2, 0.05 * 2 }, { 0.05 * 4, 0.05 * 4, 0.05 * 4 } }) [config.CURRENT_THEME],

--- a/src/common.lua
+++ b/src/common.lua
@@ -45,7 +45,8 @@ M.Color = {
         --{
         -- GREENNNNN
         background = ({ { 0.06, 0.36, 0.30 }, { 0.4, 0.4, 0.4 }, { 0.75, 0.75, 0.75 } })[config.CURRENT_THEME], -- exposure: 0.0625, decay: 0.60
-        creature_healed = { 0.45, 0.52, 0.45 },
+        -- creature_healed = { 0.45, 0.52, 0.45 }, -- before impl gradient bg shader
+        creature_healed = { 0.05, 0.02, 0.15, 0.4 },  -- after impl gradient bg shader
         creature_infected = ({ { 0.05, 0.02, 0.15 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME], -- green low_light
 
         -- BLUUEUUEUE
@@ -53,45 +54,19 @@ M.Color = {
         -- creature_healed = { 0.45, 0.45, 0.75 },
         -- creature_infected = ({ { 0.05, 0.02, 0.15 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME], -- green low_light
 
-        -- background = ({ { 0.06, 0.16, 0.38 }, { 0.4, 0.4, 0.4 }, { 0.75, 0.75, 0.75 } })[config.CURRENT_THEME], -- exposure: 0.0625, decay: 0.60
-        -- creature_infected = ({ { 0.05, 0.09, 0.23 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME], -- green low_light
-        --}
-
-        -- creature_infected = ({ { 0.25, 0.9, 0.6 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME], -- green low_light
-        -- creature_infected = (({ { 0.76, 0.05, 0.25 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME]), -- red low_light
-
-        -- creature_infected = (({ { 0.25, 0.9, 0.6 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME]), -- green low_light
-        -- creature_infected = (({ { 0.46, 0.16, 0.19 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME]), -- magenta low_light
-        -- creature_infected = (({ { 0.65, 1.00, 0.60 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME]), -- beserk low_light
-        -- creature_infected = (({ { 0.86, 0.40, 0.55 }, { 0.25 + 0.1, 0.9 + 0.1, 0.6 + 0.2 }, { 0.05, 0.05, 0.05 } })[config.CURRENT_THEME]), -- red low_light
-        -- creature_infected = { 0.2, 0.9, 0.6 }, -- green (works with all themes)
-        -- creature_infected = { 0.75, 0.1, 0.3 },
-
-        -- background = { 0.4, 0.4, 0.4 },-- exposure: 0.0625, decay: 0.60
-        -- background = { 0.75, 0.75, 0.75 }, -- exposure: 0.325, decay: 0.75
-        -- background = { 0.9, 0.9, 0.9 }, -- exposure: 0.325, decay: 0.75
-        -- creature_healed = { 0.85, 0.85, 0.85 },
-        -- creature_healing = { 0.95, 0.4, 0.6 }, --- (pink)
-        -- creature_infected_rgba = { 0.75, 0.1, 0.3, 0.5 },
-        -- player_beserker_modifier = { 0.9, 0.9, 0.4 },                          --- Enhanced abilities, when either of shift key is pressed.
-        -- player_entity = { 0.3, 0.3, 0.3 }, --- The dark backdrop (galaxy like) of the eye. (charcoal)
-        -- player_entity_firing_projectile = { 155 / 255, 190 / 255, 128 / 255 }, -- green mint
-        -- player_entity_firing_projectile = { 230 / 255, 230 / 255, 250 / 255 }, -- lavender
         creature_healing = { 0.85, 0.3, 0.5 }, --- (pink)
         creature_infected_rgba = { 0.65, 0.1, 0.2, 0.5 },
+
         player_beserker_dash_modifier = { 0.9, 0.9, 0.4 }, --- ??? Chaos when shift + x are down. (yellow)
-        player_beserker_modifier = { 155 / 255, 190 / 255, 128 / 255 }, --- buttercup Enhanced abilities, when either of shift key is pressed. (green)
-        player_dash_neonblue_modifier = { 0.7, 0.7, 1.0 }, --- bubbles (luminiscent blue)
+        player_beserker_modifier = { 135 / 255, 280 / 255, 138 / 255 }, --- buttercup Enhanced abilities, when either of shift key is pressed. (green)
+        player_dash_neonblue_modifier = { 0.8, 0.8, 1.0 }, --- bubbles (luminiscent blue)
         player_dash_pink_modifier = { 0.95, 0.4, 0.6 }, --- blossom The idle tail and projectile color. (purple)
         player_dash_yellow_modifier = { 0.9, 0.9, 0.4 }, --- You see, you're not dealing with the average player. (yellow)
-        player_entity = ({
-                { 0.05 * 1, 0.05 * 1, 0.05 * 1 },
-                { 0.05 * 2, 0.05 * 2, 0.05 * 2 },
-                { 0.05 * 4, 0.05 * 4, 0.05 * 4 },
-        })[config.CURRENT_THEME],
+        player_entity = ({ { 0.05 * 1, 0.05 * 1, 0.05 * 1 }, { 0.05 * 2, 0.05 * 2, 0.05 * 2 }, { 0.05 * 4, 0.05 * 4, 0.05 * 4 } }) [config.CURRENT_THEME],
         player_entity_firing_edge_dark = { 0.8, 0.8, 0.8 }, --- The "scanner|trigger|glint" of the eye ^_^. (offwhite)
         player_entity_firing_edge_darker = { 0.8, 0.8, 0.8 }, --- The lighter outer edge of the eye. (offwhite)
-        player_entity_firing_projectile = { 155 / 255, 128 / 255, 190 / 255 }, --- The idle tail and projectile color. (purple)
+        player_entity_firing_projectile = { 125 / 255, 148 / 255, 290 / 255 }, --- The idle tail and projectile color. (purple)
+
         text_darker = { 0.4, 0.4, 0.4 },
         text_darkest = { 0.3, 0.3, 0.3 },
         text_debug_hud = { 0.8, 0.7, 0.0 },

--- a/src/config.lua
+++ b/src/config.lua
@@ -28,12 +28,15 @@ M = {
         AIR_RESISTANCE = 0.95, --- Resistance factor between 0 and 1.
         CURRENT_THEME = Theme.low_light,
         FIXED_DT = 1 / _fixed_fps, --- Consistent update frame rate fluctuations.
-        FIXED_DT_INV = 1 / (1 / _fixed_fps), --- Helper constant to avoid dividing on each frame.
+        FIXED_DT_INV = 1 / (1 / _fixed_fps), --- Helper constant to avoid dividing on each frame. (same as FIXED_FPS)
         FIXED_FPS = _fixed_fps,
         LASER_FIRE_TIMER_LIMIT = _phi_inv * ({ 0.21, 0.16, 0.14 })[speed_mode], --- Reduce this to increase fire rate.
         LASER_PROJECTILE_SPEED = ({ 2 ^ 7, 2 ^ 8, 2 ^ 8 + 256 })[speed_mode], --- 256|512|768
-        LASER_RADIUS = math.floor(_player_radius * _phi_inv),
-        MAX_CREATURE_RADIUS = 80,
+        LASER_RADIUS = math.floor(_player_radius * _phi_inv ^ _phi),
+        MIN_CREATURE_RADIUS = 8,
+        MAX_CREATURE_RADIUS = 100,
+        MIN_CREATURE_SPEED = 20,
+        MAX_CREATURE_SPEED = 120,
         MAX_GAME_LEVELS = 2 ^ 6, -- > 64
         MAX_LASER_CAPACITY = 2 ^ 6, -- Choices: 2^4(balanced [nerfs fast fire rate]) | 2^5 (long range)
         MAX_PLAYER_HEALTH = 3,
@@ -83,6 +86,7 @@ do
         M.EXPECTED_FINAL_HEALED_CREATURE_COUNT = ((M.INITIAL_LARGE_CREATURES ^ 2) - M.INITIAL_LARGE_CREATURES) --- @type integer # Double buffer size of possible creatures count i.e. `initial count ^ 2`
         M.TOTAL_CREATURES_CAPACITY = (2 * (M.INITIAL_LARGE_CREATURES ^ 2))
 end
+
 
 local is_skip_assert = true
 if not is_skip_assert then assert(M.PLAYER_ACCELERATION / M.PLAYER_DEFAULT_TURN_SPEED <= 60, 'Expected <= 60. Actual: ' .. M.PLAYER_ACCELERATION) end

--- a/src/config.lua
+++ b/src/config.lua
@@ -67,8 +67,8 @@ M = {
         -- DEBUGGING FLAGS
 
         debug = {
-                is_assert = not true,
-                is_development = not true,
+                is_assert = true,
+                is_development = true,
                 is_test = true,
                 is_trace_entities = not true,
                 is_trace_hud = not true,
@@ -76,6 +76,13 @@ M = {
 
         Theme = Theme, -- FIXME: Shouldn't this be in common.lua?
 }
+
+M.CONSTANT_INITIAL_LARGE_CREATURES = (2 ^ 2)                                                                   -- WARN: Any more than this, and levels above 50 lag
+do
+        M.INITIAL_LARGE_CREATURES = (2 ^ 0)                                                                    --- @type integer # This count excludes the initial ancestor count.
+        M.EXPECTED_FINAL_HEALED_CREATURE_COUNT = ((M.INITIAL_LARGE_CREATURES ^ 2) - M.INITIAL_LARGE_CREATURES) --- @type integer # Double buffer size of possible creatures count i.e. `initial count ^ 2`
+        M.TOTAL_CREATURES_CAPACITY = (2 * (M.INITIAL_LARGE_CREATURES ^ 2))
+end
 
 local is_skip_assert = true
 if not is_skip_assert then assert(M.PLAYER_ACCELERATION / M.PLAYER_DEFAULT_TURN_SPEED <= 60, 'Expected <= 60. Actual: ' .. M.PLAYER_ACCELERATION) end

--- a/src/main.lua
+++ b/src/main.lua
@@ -903,16 +903,20 @@ end
 
 --- @enum PLAYER_ACTION
 local PLAYER_ACTION = {
-        BESERKER = 'BESERKER',
+        BESERK_BOOST_COMBO = 'BESERK_BOOST_COMBO',
+        BESERK = 'BESERK',
         DASH = 'DASH',
         FIRE = 'FIRE',
+        IDLE = 'IDLE',
 }
 
 --- @type table<PLAYER_ACTION, [number, number, number]>
 local PROJECTILE_TO_PLAYER_ACTION_MAP = {
-        [PLAYER_ACTION.BESERKER] = common.Color.player_beserker_modifier,
+        [PLAYER_ACTION.BESERK_BOOST_COMBO] = common.Color.player_beserker_dash_modifier,
+        [PLAYER_ACTION.BESERK] = common.Color.player_beserker_modifier,
         [PLAYER_ACTION.DASH] = common.Color.player_dash_neonblue_modifier,
         [PLAYER_ACTION.FIRE] = common.Color.player_entity_firing_projectile,
+        [PLAYER_ACTION.IDLE] = common.Color.player_entity,
 }
 
 function _draw_active_projectile(i, alpha)
@@ -923,12 +927,19 @@ function _draw_active_projectile(i, alpha)
                 pos_y = lerp(prev_state.lasers_y[i], pos_y, alpha)
         end
 
-        -- maybne this should be in its update method?
-        local player_action = ( --[[@type PLAYER_ACTION]]
-                love.keyboard.isDown('lshift', 'rshift') and PLAYER_ACTION.BESERKER --[[ beserker has higher priority than dash ]]
-                or love.keyboard.isDown 'x' and PLAYER_ACTION.DASH --[[ dash has high priorityh than fire ]]
-                or PLAYER_ACTION.FIRE
+        local is_beserk = love.keyboard.isDown('lshift', 'rshift')
+        local is_boost = love.keyboard.isDown 'x'
+        local is_beserk_boost_combo = is_beserk and is_boost
+
+        -- maybe this should be in its update method?
+        --[[@type PLAYER_ACTION]]
+        local player_action = (
+                is_beserk_boost_combo and PLAYER_ACTION.BESERK_BOOST_COMBO
+                or (is_beserk and PLAYER_ACTION.BESERK
+                        or (is_boost and PLAYER_ACTION.DASH or PLAYER_ACTION.FIRE)
+                        or PLAYER_ACTION.IDLE)
         )
+
         -- Add sprite to batch with position, rotation, scale and color
         local scale = 1 --- Scale based on original `LASER_RADIUS`.
         local origin_x = config.LASER_RADIUS

--- a/src/main.lua
+++ b/src/main.lua
@@ -51,7 +51,7 @@ local graphics_config = {
 -- Copied from [SkyVaultGames ─ Love2D | Shader Tutorial 1 | Introduction](https://www.youtube.com/watch?v=DOyJemh_7HE&t=1s)
 
 -- `vec2 uvs` is for LOVE quads
-local background_gradient_shader_code = [[
+local glsl_gradient_shader_code = [[
 extern vec2 screen;
 
 vec4 effect(vec4 color, Image image, vec2 uvs, vec2 screen_coords) {
@@ -1473,7 +1473,7 @@ function love.load()
                         .chain(fx.colorgradesimple)
                         .chain(fx.vignette),
         }
-        background_gradient_shader = LG.newShader(background_gradient_shader_code)
+        glsl_gradient_shader = LG.newShader(glsl_gradient_shader_code)
 
         if true then
                 if not true then
@@ -1819,9 +1819,9 @@ function love.draw()
         local alpha = dt_accum * config.FIXED_DT_INV --- @type number
         shaders.post_processing(function()
                 do
-                        LG.setShader(background_gradient_shader)
+                        LG.setShader(glsl_gradient_shader)
                         LG.rectangle("fill", 0, 0, arena_w, arena_h)                                 --- draw background fill, else background color shows up (maybe use LG.clearBackground())
-                        background_gradient_shader:send('screen', { LG.getWidth(), LG.getHeight() }) -- or use getDimension()???  -- shouldn't this be in update???
+                        glsl_gradient_shader:send('screen', { LG.getWidth(), LG.getHeight() }) -- or use getDimension()???  -- shouldn't this be in update???
                         do
                                 draw_background_shader(alpha)
                         end

--- a/src/main.lua
+++ b/src/main.lua
@@ -1624,20 +1624,42 @@ function love.load()
                 wait = 0.0,
         }
 
+        do
         local _creature_scale = 1
         local _speed_multiplier = 1.25
-        creature_evolution_stages = { ---@type Stage[] # Size decreases as stage progresses.
-                { speed = 90 * _speed_multiplier, radius = math.ceil(15 * _creature_scale) },
-                { speed = 70 * _speed_multiplier, radius = math.ceil(30 * _creature_scale) },
-                { speed = 50 * _speed_multiplier, radius = math.ceil(50 * _creature_scale) },
-                { speed = 20 * _speed_multiplier, radius = math.ceil(80 * _creature_scale) },
+
+                ---@type Stage[] # Size decreases as stage progresses.
+                creature_evolution_stages = {
+                        {
+                                speed = math.min(config.MAX_CREATURE_SPEED, math.floor(config.MIN_CREATURE_SPEED * (PHI ^ 3.8) * _speed_multiplier)),
+                                radius = math.max(config.MIN_CREATURE_RADIUS, math.ceil(config.MAX_CREATURE_RADIUS * (PHI_INV ^ 5) * _creature_scale)),
+                        },
+                        {
+                                speed = math.floor(config.MIN_CREATURE_SPEED * (PHI ^ 3) * _speed_multiplier),
+                                radius = math.ceil(config.MAX_CREATURE_RADIUS * (PHI_INV ^ 3) * _creature_scale)
+                        },
+                        {
+                                speed = math.floor(config.MIN_CREATURE_SPEED * (PHI ^ 2) * _speed_multiplier),
+                                radius = math.ceil(config.MAX_CREATURE_RADIUS * (PHI_INV ^ 2) * _creature_scale)
+                        },
+                        {
+                                speed = math.floor(config.MIN_CREATURE_SPEED * (PHI ^ 0) * _speed_multiplier),
+                                radius = math.ceil(config.MAX_CREATURE_RADIUS * (PHI_INV ^ 0) * _creature_scale)
+                        },
         }
         do -- Test `creature_evolution_stages`.
                 local max_creature_mutation_count = 0
                 for i = 1, #creature_evolution_stages do
                         max_creature_mutation_count = max_creature_mutation_count + i
+                                local stage = creature_evolution_stages[i]
+                                local speed = stage.speed
+                                local radius = stage.radius
+                                assert(speed > config.MIN_CREATURE_SPEED and speed <= config.MAX_CREATURE_SPEED)
+                                assert(radius >= config.MIN_CREATURE_RADIUS and radius <= config.MAX_CREATURE_RADIUS)
                 end
-                assert(max_creature_mutation_count == 10, 'Assert 1 creature (ancestor) »»mutates»» into ten creatures including itself.')
+                        assert(max_creature_mutation_count == 10,
+                                'Assert 1 creature (ancestor) »»mutates»» into ten creatures including itself.')
+                end
         end
 
         is_debug_hud_enabled = not true --- Toggled by keys event.

--- a/src/stylua.toml
+++ b/src/stylua.toml
@@ -1,0 +1,12 @@
+# sytlua.toml
+
+column_width = 160
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 8
+quote_style = "AutoPreferSingle"
+call_parentheses = "None"
+collapse_simple_statement = "Always" # Choices: `Never`, `FunctionOnly`, `ConditionalOnly`, `Always`
+
+[sort_requires]
+enabled = true

--- a/stylua.toml
+++ b/stylua.toml
@@ -1,0 +1,12 @@
+# sytlua.toml
+
+column_width = 160
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 8
+quote_style = "AutoPreferSingle"
+call_parentheses = "None"
+collapse_simple_statement = "Always" # Choices: `Never`, `FunctionOnly`, `ConditionalOnly`, `Always`
+
+[sort_requires]
+enabled = true


### PR DESCRIPTION
## What's new

Draws background as a 2-color prominent gradient. Thanks to [SkyVaultGames](https://www.youtube.com/watch?v=DOyJemh_7HE&t=1s)

## Changes

- [Add WIP gradient shader](https://github.com/lloydlobo/tinycreatures/pull/19/commits/fe3a447bc31c774e3de7fc0080fcb8b064d8e42b)
- [Update projectile color enumeration for beserk dash combo](https://github.com/lloydlobo/tinycreatures/pull/19/commits/9b9ad6632b26a9b21c3717319c5a507f6a53680c)
- [Add more shader color variant options](https://github.com/lloydlobo/tinycreatures/pull/19/commits/5d2609a55cb78943291fd2f0f5d17f467fb3ee2c)
- [Rename gradient shader](https://github.com/lloydlobo/tinycreatures/pull/19/commits/b9ef5b385c087a32ecf06657ea4f7b3704c731ec)
- [Use golden ratio multiplier for each creature evolution stage](https://github.com/lloydlobo/tinycreatures/pull/19/commits/fca0acc62199e4613c50630211b8b8cfcc966fb1)
