### PR TITLE
Tidy keyboard enums

### DIFF
--- a/src/common.lua
+++ b/src/common.lua
@@ -89,16 +89,14 @@ M.COLOR = {
     creature_healing = { 0.85, 0.3, 0.5 }, --- (pink)
     creature_infected_rgba = { 0.65, 0.1, 0.2, 0.5 },
 
-    player_beserker_dash_modifier = { 0.9, 0.9, 0.4 }, --- ??? Chaos when shift + x are down. (yellow)
+    player_beserker_dash_modifier = { 0.4, 1.0, 1. }, --- Chaos when shift + x are down. (luminiscent blue)
     player_beserker_modifier = { 135 / 255, 280 / 255, 138 / 255 }, --- buttercup Enhanced abilities, when either of shift key is pressed. (green)
-    -- player_dash_neonblue_modifier = { 0.8, 0.8, 1.0 }, --- bubbles (luminiscent blue)
-    player_dash_neonblue_modifier = { 0.85, 0.85, 0.95 }, --- bubbles (luminiscent blue)
+    player_boost_dash_modifier = { 0.85, 0.85, 0.35 }, --- bubbles (luminiscent yellow)
     player_dash_pink_modifier = { 0.95, 0.4, 0.6 }, --- blossom The idle tail and projectile color. (purple)
-    player_dash_yellow_modifier = { 0.9, 0.9, 0.4 }, --- You see, you're not dealing with the average player. (yellow)
     player_entity = ({ { 0.05 * 1, 0.05 * 1, 0.05 * 1 }, { 0.05 * 2, 0.05 * 2, 0.05 * 2 }, { 0.05 * 4, 0.05 * 4, 0.05 * 4 } })[Config.CURRENT_THEME],
     player_entity_firing_edge_dark = { 0.8, 0.8, 0.8 }, --- The "scanner|trigger|glint" of the eye ^_^. (offwhite)
     player_entity_firing_edge_darker = { 0.8, 0.8, 0.8 }, --- The lighter outer edge of the eye. (offwhite)
-    player_entity_firing_projectile = { 125 / 255, 148 / 255, 290 / 255 }, --- The idle tail and projectile color. (purple)
+    player_entity_firing_projectile = { 1., 1., 1. }, --- The idle tail and projectile color. (white)
 
     TEXT_DARKER = { 0.4, 0.4, 0.4 },
     TEXT_DARKEST = { 0.3, 0.3, 0.3 },
@@ -121,7 +119,7 @@ end
 M.PLAYER_ACTION_TO_COLOR = {
     [M.PLAYER_ACTION.COMBO_BESERK_BOOST] = M.COLOR.player_beserker_dash_modifier,
     [M.PLAYER_ACTION.BESERK] = M.COLOR.player_beserker_modifier,
-    [M.PLAYER_ACTION.BOOST] = M.COLOR.player_dash_neonblue_modifier,
+    [M.PLAYER_ACTION.BOOST] = M.COLOR.player_boost_dash_modifier,
     [M.PLAYER_ACTION.FIRE] = M.COLOR.player_entity_firing_projectile,
     [M.PLAYER_ACTION.IDLE] = M.COLOR.player_entity_firing_edge_dark, -- for laser
 }
@@ -130,7 +128,7 @@ M.PLAYER_ACTION_TO_COLOR = {
 M.PLAYER_ACTION_TO_DESATURATED_COLOR = {
     [M.PLAYER_ACTION.COMBO_BESERK_BOOST] = M.desaturate(M.COLOR.player_beserker_dash_modifier),
     [M.PLAYER_ACTION.BESERK] = M.desaturate(M.COLOR.player_beserker_modifier),
-    [M.PLAYER_ACTION.BOOST] = M.desaturate(M.COLOR.player_dash_neonblue_modifier),
+    [M.PLAYER_ACTION.BOOST] = M.desaturate(M.COLOR.player_boost_dash_modifier),
     [M.PLAYER_ACTION.FIRE] = M.desaturate(M.COLOR.player_entity_firing_projectile),
     [M.PLAYER_ACTION.IDLE] = M.desaturate(M.COLOR.player_entity_firing_edge_dark), -- for laser and creature light phong
 }

--- a/src/common.lua
+++ b/src/common.lua
@@ -19,6 +19,9 @@ M.HEALTH_TRANSITIONS = {
 
 --- @enum CONTROL_KEY
 M.CONTROL_KEY = {
+    BESERK_LSHIFT = 'lshift',
+    BESERK_RSHIFT = 'lshift',
+    BOOST = 'x', --- `x`─Boost player
     ESCAPE_KEY = 'escape',
     FIRE = 'space',
     FORCE_QUIT_GAME = 'q',

--- a/src/config.lua
+++ b/src/config.lua
@@ -16,24 +16,22 @@ local Theme = {
 
 local _speed_mode = Mode.ADVANCED
 
-local _creature_initial_large_count = (2 ^ 1) --[[NOTE: Increase this for more challenging levels that are not trivial]]
-local _creatures_initial_constant_large_count = (2 ^ 3)
 local _fixed_fps = 60
 local _inv_phi = 0.618
 local _phi = 1.618
-local _player_accel = ({ 150, 200, 300 })[_speed_mode]
-local _player_radius = (32 * 0.61) - 4
 
 --- @class (exact) CreatureStage
 --- @field radius integer
 --- @field speed number
 
-local _cret_max_radius = 100
-local _cret_max_speed = 120
+local _creature_initial_large_count = (2 ^ 1) --[[NOTE: Increase this for more challenging levels that are not trivial]]
+local _creatures_initial_constant_large_count = (2 ^ 3)
+local _cret_max_radius = 92
+local _cret_max_speed = 100 -- 32..120
 local _cret_min_radius = 8
 local _cret_min_speed = 32
-local _f_cret_scale = 1 -- factor
-local _f_cret_speed = 1.35 -- factor
+local _f_cret_scale = 1. -- factor
+local _f_cret_speed = 1. -- factor
 
 --- @type CreatureStage[] Size decreases as stage progresses.
 local _CREATURE_STAGES = {
@@ -54,6 +52,9 @@ local _CREATURE_STAGES = {
         speed = math.floor(_cret_min_speed * (_phi ^ 0) * _f_cret_speed),
     },
 }
+
+local _player_accel = ({ 150, 200, 300 })[_speed_mode]
+local _player_radius = math.min(_CREATURE_STAGES[1].radius * _phi, (32 * 0.61) - 4)
 
 --- @class (exact) MoonshineShaderSettings
 --- @field bloom_intensity { enable: boolean, amount: number }
@@ -174,7 +175,7 @@ return {
     LASER_FIRE_TIMER_LIMIT = _inv_phi * ({ 0.21, 0.16, 0.14 })[_speed_mode], --- Reduce this to increase fire rate.
     LASER_MAX_CAPACITY = 2 ^ 6, -- Choices: 2^4(balanced [nerfs fast fire rate]) | 2^5 (long range)
     LASER_PROJECTILE_SPEED = ({ 2 ^ 7, 2 ^ 8, 2 ^ 8 + 256 })[_speed_mode], --- 256|512|768
-    LASER_RADIUS = math.floor(_player_radius * (_inv_phi ^ (1 * _phi))),
+    LASER_RADIUS = math.max(_inv_phi * _player_radius, math.floor(_player_radius * (_inv_phi ^ (1 * _phi)))),
     PARALLAX_ENTITY_IMG_RADIUS = 48,
     PARALLAX_ENTITY_MAX_COUNT = (2 ^ 4),
     PARALLAX_ENTITY_MAX_DEPTH = 2, --- @type integer

--- a/src/main.lua
+++ b/src/main.lua
@@ -748,9 +748,11 @@ function handle_player_input_this_frame(dt)
     end
 
     do -- FIXME: Let it be or move each action to (if/elseif/else) checks above
-        local is_beserk = love.keyboard.isDown('lshift', 'rshift')
-        local is_boost = love.keyboard.isDown 'x'
-        local is_firing = love.keyboard.isDown 'space'
+        local KEY = Common.CONTROL_KEY
+        local is_beserk = love.keyboard.isDown(KEY.BESERK_LSHIFT, KEY.BESERK_RSHIFT)
+        local is_boost = love.keyboard.isDown(KEY.BOOST)
+        local is_firing = love.keyboard.isDown(KEY.FIRE)
+
         if love.keyboard.isDown 'x' then
             local should_play_once = not music_sci_fi_engine:isPlaying() or music_sci_fi_engine_is_fading_out
             if should_play_once then sound_boost_impulse:play() end

--- a/src/main.lua
+++ b/src/main.lua
@@ -788,18 +788,15 @@ local dest_trail_color = { 0, 0, 0 } --- WARN: Initialize zero value (this is th
 function draw_player_trail(alpha)
     local IS_ENLARGE_PLAYER_TRAIL_ON_DAMAGE = true
 
-    local clr_green = Common.COLOR.player_beserker_modifier
-    local clr_yellow = Common.COLOR.player_dash_yellow_modifier
     local invulnerability_timer = curr_state.player_invulnerability_timer
     local is_beserker = love.keyboard.isDown('lshift', 'rshift')
     local is_boost = love.keyboard.isDown 'x'
     if is_beserker and is_boost then
-        Common.lerp_rbg(dest_trail_color, clr_green, clr_yellow, alpha)
-        LG.setColor(dest_trail_color)
+        LG.setColor(Common.COLOR.player_beserker_dash_modifier)
     elseif is_beserker then
-        LG.setColor(clr_green)
+        LG.setColor(Common.COLOR.player_beserker_modifier)
     elseif is_boost then
-        LG.setColor(Common.COLOR.player_dash_neonblue_modifier)
+        LG.setColor(Common.COLOR.player_boost_dash_modifier)
     else
         LG.setColor(Common.COLOR.player_entity_firing_projectile)
     end
@@ -875,6 +872,7 @@ function draw_player(alpha)
     local player_angle = lerp(prev_state.player_rot_angle, cs.player_rot_angle, alpha)
     local player_x = lerp(prev_state.player_x, cs.player_x, alpha)
     local player_y = lerp(prev_state.player_y, cs.player_y, alpha)
+    local player_radius = Config.PLAYER_RADIUS
 
     local is_interpolate_player = true
     if is_interpolate_player then
@@ -888,7 +886,7 @@ function draw_player(alpha)
         if (cs.player_health == 1) and (love.math.random() < 0.1 * alpha) then
             local clr = Common.COLOR.creature_healing
             LG.setColor(clr[1], clr[2], clr[3], lerp(0.2, 0.4, alpha))
-            LG.circle('fill', player_x, player_y, Config.PLAYER_RADIUS)
+            LG.circle('fill', player_x, player_y, player_radius)
         end
     end
 
@@ -908,14 +906,14 @@ function draw_player(alpha)
     LG.circle('fill', player_x, player_y, player_iris_radius)
 
     -- Draw player player firing trigger • (circle)
-    local dest_trigger_x = player_x + math.cos(player_angle) * Config.PLAYER_FIRING_EDGE_MAX_RADIUS
-    local dest_trigger_y = player_y + math.sin(player_angle) * Config.PLAYER_FIRING_EDGE_MAX_RADIUS
+    local fire_pos_x = player_x + math.cos(player_angle) * Config.PLAYER_FIRING_EDGE_MAX_RADIUS
+    local fire_pos_y = player_y + math.sin(player_angle) * Config.PLAYER_FIRING_EDGE_MAX_RADIUS
     local firing_trigger_radius = Config.PLAYER_FIRING_EDGE_RADIUS
     local invulnerability_timer = cs.player_invulnerability_timer
 
     local trigger_radius = lerp( --
-        firing_trigger_radius - 3,
         firing_trigger_radius - 1,
+        firing_trigger_radius - 0,
         lume.clamp(math.sin(game_timer_t * 2.) / 2., 0., 1.)
         -- alpha + (invulnerability_timer * 0.5)
     )
@@ -951,13 +949,37 @@ function draw_player(alpha)
             do -- Apply inertia to dest position.
                 local dfactor = true and 0.328 or (INV_PHI * 0.8) -- ideal: .328 (distance factor)
                 local amplitude_factor = is_player_going_backwards and 0.125 or 0.35
-                dest_trigger_x = dest_trigger_x - (dfactor * amplitude_factor * Config.PLAYER_FIRING_EDGE_MAX_RADIUS) * (inertia_x * game_timer_dt)
-                dest_trigger_y = dest_trigger_y - (dfactor * amplitude_factor * Config.PLAYER_FIRING_EDGE_MAX_RADIUS) * (inertia_y * game_timer_dt)
+                fire_pos_x = fire_pos_x - (dfactor * amplitude_factor * Config.PLAYER_FIRING_EDGE_MAX_RADIUS) * (inertia_x * game_timer_dt)
+                fire_pos_y = fire_pos_y - (dfactor * amplitude_factor * Config.PLAYER_FIRING_EDGE_MAX_RADIUS) * (inertia_y * game_timer_dt)
             end
         end
     end
-    LG.setColor(Common.COLOR.player_entity_firing_edge_dark)
-    LG.circle('fill', dest_trigger_x, dest_trigger_y, trigger_radius)
+    if player_action ~= Common.PLAYER_ACTION.IDLE then
+        local prev_line_width = LG.getLineWidth()
+        LG.setLineWidth(3)
+        do
+            local triangle_size = 0.88 * player_radius
+            local angle = cs.player_rot_angle
+            local pos_x_
+            local pos_y_
+            pos_x_ = player_x
+            pos_y_ = player_y
+            pos_x_ = fire_pos_x
+            pos_y_ = fire_pos_y
+            local x1 = pos_x_ + math.cos(angle) * triangle_size -- ze pointy end
+            local y1 = pos_y_ + math.sin(angle) * triangle_size
+            local x2 = pos_x_ + math.cos(angle + PI * 0.75) * triangle_size
+            local y2 = pos_y_ + math.sin(angle + PI * 0.75) * triangle_size
+            local x3 = pos_x_ + math.cos(angle - PI * 0.75) * triangle_size
+            local y3 = pos_y_ + math.sin(angle - PI * 0.75) * triangle_size
+            LG.setColor(Common.PLAYER_ACTION_TO_COLOR[player_action])
+            LG.polygon('line', x1, y1, x2, y2, x3, y3)
+        end
+        LG.setLineWidth(prev_line_width)
+    else
+        LG.setColor(Common.COLOR.player_entity_firing_edge_dark)
+        LG.circle('fill', fire_pos_x, fire_pos_y, trigger_radius)
+    end
 end
 
 local temp_last_ouch_x = nil
@@ -1394,7 +1416,7 @@ function draw_game(alpha)
     draw_player_fired_projectiles(alpha)
     -- Shaders.phong_lighting.shade_player_trail(function() draw_player_trail(alpha) end)
     draw_player_trail(alpha)
-    draw_player_direction_ray(alpha)
+    -- draw_player_direction_ray(alpha)
     draw_player_shield_collectible(alpha)
     draw_player(alpha)
 end


### PR DESCRIPTION
Experiment with player trigger shape. This will change.

## Commits

- `c4ceb6c` [Use enums for isDown events](https://github.com/lloydlobo/tinycreatures/pull/24/commits/c4ceb6cd0ac18d5404dbba667265053e5f8fd70d)
- `c4dd979` [Draw player triangle trigger instead of circle when not idle](https://github.com/lloydlobo/tinycreatures/pull/24/commits/c4dd9790bbe5432386af58a6d1cc6e4983c750a8)
