### PR TITLE
Draw elapsed game time

### DIFF
--- a/src/config.lua
+++ b/src/config.lua
@@ -183,7 +183,7 @@ return {
     LASER_FIRE_TIMER_LIMIT = (_inv_phi ^ 0) * ({ 0.21, 0.16, 0.14 })[_speed_mode], --- Reduce this to increase fire rate.
     LASER_MAX_CAPACITY = 2 ^ 8, -- Choices: 2^4(balanced [nerfs fast fire rate]) | 2^5 (long range)
     LASER_PROJECTILE_SPEED = ({ 2 ^ 7, 2 ^ 8, 2 ^ 8 + 256 })[_speed_mode], --- 256|512|768
-    LASER_RADIUS = 0.7 * math.max(_inv_phi * _player_radius, math.floor(_player_radius * (_inv_phi ^ (1 * _phi)))),
+    LASER_RADIUS = _inv_phi * math.max(_inv_phi * _player_radius, math.floor(_player_radius * (_inv_phi ^ (1 * _phi)))),
     PARALLAX_ENTITY_IMG_RADIUS = 48,
     PARALLAX_ENTITY_MAX_COUNT = (2 ^ 3),
     PARALLAX_ENTITY_MAX_DEPTH = 4, --- @type integer

--- a/src/config.lua
+++ b/src/config.lua
@@ -183,14 +183,14 @@ return {
     LASER_FIRE_TIMER_LIMIT = (_inv_phi ^ 0) * ({ 0.21, 0.16, 0.14 })[_speed_mode], --- Reduce this to increase fire rate.
     LASER_MAX_CAPACITY = 2 ^ 8, -- Choices: 2^4(balanced [nerfs fast fire rate]) | 2^5 (long range)
     LASER_PROJECTILE_SPEED = ({ 2 ^ 7, 2 ^ 8, 2 ^ 8 + 256 })[_speed_mode], --- 256|512|768
-    LASER_RADIUS = 0.5 * math.max(_inv_phi * _player_radius, math.floor(_player_radius * (_inv_phi ^ (1 * _phi)))),
+    LASER_RADIUS = 0.7 * math.max(_inv_phi * _player_radius, math.floor(_player_radius * (_inv_phi ^ (1 * _phi)))),
     PARALLAX_ENTITY_IMG_RADIUS = 48,
-    PARALLAX_ENTITY_MAX_COUNT = (2 ^ 2),
+    PARALLAX_ENTITY_MAX_COUNT = (2 ^ 3),
     PARALLAX_ENTITY_MAX_DEPTH = 4, --- @type integer
-    PARALLAX_ENTITY_MIN_DEPTH = 1, --- @type integer
+    PARALLAX_ENTITY_MIN_DEPTH = 0, --- @type integer
     PARALLAX_ENTITY_RADIUS_FACTOR = 16, --- QUESTION: Are we scaling up by this factor? (should ensure resulting radius is similar to `PARALLAX_ENTITY_IMG_RADIUS`)
-    PARALLAX_OFFSET_FACTOR_X = 0.01, -- NOTE: Should be lower to avoid puking
-    PARALLAX_OFFSET_FACTOR_Y = 0.01,
+    PARALLAX_OFFSET_FACTOR_X = 0.00, -- NOTE: Should be lower to avoid puking
+    PARALLAX_OFFSET_FACTOR_Y = 0.00,
     PLAYER_ACCELERATION = math.floor(3 * (true and 1 or 1.25) * ({ 150, 200, 300 })[_speed_mode]),
     PLAYER_CIRCLE_IRIS_TO_EYE_RATIO = _inv_phi,
     PLAYER_DEFAULT_TURN_SPEED = ({ (10 * _inv_phi), 10, -2 + (30 / 2) / 4 + (_player_accel / _fixed_fps) })[_speed_mode],
@@ -200,5 +200,5 @@ return {
     PLAYER_MAX_HEALTH = 4,
     PLAYER_MAX_TRAIL_COUNT = 8, -- (-2 + math.floor(math.pi * math.sqrt(_player_radius * _inv_phi))), -- player_radius(32)*PHI==20(approx)
     PLAYER_RADIUS = _player_radius,
-    PLAYER_TRAIL_THICKNESS = (1.0 * math.ceil(_player_radius * _inv_phi)), -- HACK: 32 is player_radius global var in love.load (same size as dark of eye looks good)
+    PLAYER_TRAIL_THICKNESS = (1.2 * math.ceil(_player_radius * _inv_phi)), -- HACK: 32 is player_radius global var in love.load (same size as dark of eye looks good)
 }

--- a/src/main.lua
+++ b/src/main.lua
@@ -817,6 +817,7 @@ function handle_player_input_this_frame(dt)
     end
 
     -- Update and assign new player action
+    -- NOTE: What if the actions are actual keyboard like one-shot modes─like CAPSLOCK, so it needs to be switched that way....
     do
         if is_boosting then
             player_action = Common.PLAYER_ACTION.BOOST
@@ -1522,34 +1523,27 @@ function draw_player_status_bar(alpha)
 end
 
 function draw_timer_text()
-    local x = (arena_w * 0.5)
-    local y = 14
-
     local text = string.format('%.2f', game_timer_t)
     local tw, th = font:getWidth(text), font:getHeight()
 
-    -- Draw rounded rectangle button like backdrop.
-    if true then
-        if true then
-            local game_freq = math.sin(game_timer_t * 4) / 4
-            -- local f = lume.clamp((1 - game_freq), INV_PHI, PHI)
-            local f = lume.clamp((1 + game_freq), INV_PHI, PHI)
-            f = smoothstep(f, 1 + f * INV_PHI_SQ, f ^ 1.2)
+    local x = (arena_w * 0.5)
+    local y = 14
 
-            local rect_w = tw * (INV_PHI + 0.15)
-            -- Save state.
-            local blend_mode = LG.getBlendMode()
-            LG.setBlendMode('lighten', 'premultiplied')
-            LG.setColor(0.2, 0.2, 0.2, 0.5)
-            LG.rectangle('fill', x - rect_w * 0.5, y - th * f, rect_w, th * f * 2)
-            LG.circle('fill', x - rect_w * 0.5, y, th * f)
-            LG.circle('fill', x + rect_w * 0.5, y, th * f)
-            -- Restore state.
-            LG.setBlendMode(blend_mode)
-        else
-            LG.setColor(1.0, 1.0, 1.0, 1.0)
-            LG.ellipse('fill', x, y, tw * 0.7, tw * 0.7)
-        end
+    if Config.IS_GRUG_BRAIN then
+        -- Draw rounded rectangle button like backdrop.
+        local game_freq = math.sin(game_timer_t * 4) / 4
+        local f = lume.clamp((1 + game_freq), INV_PHI, PHI)
+        f = smoothstep(f, 1 + f * INV_PHI_SQ, f ^ 1.2)
+        -- Save state.
+        local blend_mode = LG.getBlendMode()
+        LG.setBlendMode('lighten', 'premultiplied')
+        LG.setColor(0.2, 0.2, 0.2, 0.5)
+        local rect_w = tw * (INV_PHI + 0.15)
+        LG.rectangle('fill', x - rect_w * 0.5, y - th * f, rect_w, th * f * 2)
+        LG.circle('fill', x - rect_w * 0.5, y, th * f)
+        LG.circle('fill', x + rect_w * 0.5, y, th * f)
+        -- Restore state.
+        LG.setBlendMode(blend_mode)
     end
 
     -- Draw timer text.


### PR DESCRIPTION
## What's changed

- Render elapsed game time per level above player's health status bar.


## Future improvements

- Consider reducing function calls to adjust final text render position based on font style

## Commits

`849981b` [Draw elapse game time](https://github.com/lloydlobo/tinycreatures/pull/31/commits/849981ba9c4473135b00c87aa16ff885399de075)
`bcd76c6` [Curb complexity while rendering timer](https://github.com/lloydlobo/tinycreatures/pull/31/commits/bcd76c604aca8398bfc3b7fc359e09d9889b0f92)