### PR TITLE
Remove background moonshine shaders and add player glow

### DIFF
--- a/src/main.lua
+++ b/src/main.lua
@@ -2238,8 +2238,9 @@ function love.draw()
             local blend_mode = LG.getBlendMode()
             LG.setBlendMode(Config.Debug.IS_DEVELOPMENT and 'multiply' or 'screen', 'premultiplied') -- screen|lighten work well
 
+            --- PERF: A glow radial gradient texture may help shader switch calls
             Shaders.phong_lighting.shade_any_to_player_pov(function()
-                LG.setColor(0, 1, 1, 0.0)
+                LG.setColor(1, 1, 1, 1)
                 LG.rectangle('fill', 0, 0, arena_w, arena_h)
             end)
             LG.setBlendMode(blend_mode)

--- a/src/main.lua
+++ b/src/main.lua
@@ -275,14 +275,16 @@ function fire_player_projectile() --- Fire projectile from players's position.
     end
 end
 
-local MAX_SPEED_BOOST_MULTIPLIER = 1.05 -- PHI
+local MAX_SPEED_BOOST_MULTIPLIER = 1.25
 local IS_SMOOTH_BOOST = true
 --- TODO: Use dash timer for Renderer to react to it, else use key event to detect dash (hack).
 function boost_player_entity_speed(dt)
     local cs = curr_state
     local prev_vel_x = cs.player_vel_x
     local prev_vel_y = cs.player_vel_y
-    local ease = INV_PHI
+    local game_freq = lume.clamp(math.sin(4 * game_timer_t) / 2, 0., 1.)
+    local ease = smoothstep(game_freq ^ 0.8, game_freq ^ 1.2, game_freq) --* PHI
+
     -- can use lerp here for smooth speed easing
     if IS_SMOOTH_BOOST then
         cs.player_vel_x = smoothstep(prev_vel_x, prev_vel_x * MAX_SPEED_BOOST_MULTIPLIER, ease)
@@ -821,6 +823,8 @@ function handle_player_input_this_frame(dt)
     do
         if is_boosting then
             player_action = Common.PLAYER_ACTION.BOOST
+            -- cs.player_invulnerability_timer = 1.0 - cs.player_invulnerability_timer
+            cs.player_invulnerability_timer = 1.0
         elseif has_companions then
             player_action = Common.PLAYER_ACTION.COMPANION
         elseif is_stop_and_beserk_in_place then
@@ -865,7 +869,8 @@ function draw_player_trail(alpha)
     local amplitude = 1
     local wiggle_rate = 1.0
     local wiggle_freq = alpha
-    local game_freq = math.sin(game_timer_t * 8) / 8
+    -- local game_freq = math.sin(game_timer_t * 8) / 8
+    local game_freq = lume.clamp(math.sin(8 * game_timer_t) / 8, 0., 1.)
     wiggle_freq = smoothstep(wiggle_freq, game_freq, game_freq)
 
     local last_f = 0.

--- a/src/main.lua
+++ b/src/main.lua
@@ -1511,8 +1511,9 @@ function draw_player_status_bar(alpha)
             LG.rectangle('fill', bar_x, bar_y + bar_height * sh, bar_width * sw, invulnerability_bar_height * sh) -- missing health
             local invulnerable_tween = invulnerability_timer
             if Config.IS_GRUG_BRAIN then invulnerable_tween = lerp(invulnerability_timer - game_timer_dt, invulnerability_timer, alpha) end
-            LG.setColor(0, 1, 1) -- cyan?????
-            LG.rectangle('fill', bar_x, bar_y + bar_height * sh, (bar_width * invulnerable_tween) * sw, invulnerability_bar_height * sh) -- current invulnerability
+            -- LG.setColor(0, 1, 1) -- cyan?????
+            LG.setColor(Common.COLOR.player_boost_dash_modifier) -- recharging ...
+            LG.rectangle('fill', bar_x, bar_y + bar_height * sh, (bar_width * invulnerable_tween) * sw, 1 + invulnerability_bar_height * sh) -- current invulnerability
         else
             temp_last_ouch_x = nil
             temp_last_ouch_y = nil
@@ -2264,7 +2265,6 @@ function love.draw()
                 LG.translate(x * arena_w, y * arena_h)
                 draw_screenshake_fx(alpha)
                 draw_game(alpha)
-
                 LG.origin() -- Reverse any previous calls to love.graphics.
             end
         end

--- a/src/shaders/phong_lighting.lua
+++ b/src/shaders/phong_lighting.lua
@@ -54,36 +54,37 @@ local light_active_creatures_screen_coords = { gw, gh }
 local light_player_trail_screen_coords = { gw, gh }
 
 --- @class (exact) Light
-local light_active_creatures = {
-    position = { 0, 0 },
-    diffuse = LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR,
-    power = 64,
-}
-
---- @class (exact) Light
 local light_player_trail = {
     position = { 0, 0 },
     diffuse = LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR,
     power = 32,
 }
 
-local function shade_active_creatures_to_player_pov(fun)
-    local shader = glsl_love_shaders.lighting_phong
+--- @class (exact) Light
+local light_any_to_player_pov = {
+    position = { 0, 0 },
+    diffuse = LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR,
+    power = 64,
+}
+
+local function shade_any_to_player_pov(fun)
+    local shader = glsl_shaders.lighting_phong
     LG.setShader(shader)
 
     local cs = curr_state
     light_active_creatures_screen_coords[1], light_active_creatures_screen_coords[2] = LG.getDimensions() -- shader:send('screen', { LG.getWidth(), LG.getHeight() })
-    light_active_creatures.position[1], light_active_creatures.position[2] = cs.player_x, cs.player_y -- TODO: use func args
-    light_active_creatures.diffuse = LIGHT_DIFFUSE_COLORS[player_action] or LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR -- TODO: send color in func args
+    light_any_to_player_pov.position[1], light_any_to_player_pov.position[2] = cs.player_x, cs.player_y -- TODO: use func args
+    -- light_any_to_player_pov.diffuse = { 0.5, 0.5, 0.5 }
+    light_any_to_player_pov.diffuse = LIGHT_DIFFUSE_COLORS[player_action] or LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR -- TODO: send color in func args
 
     shader:send('screen', light_active_creatures_screen_coords)
     shader:send('num_lights', 1)
 
     -- NOTE: First array offset is 0 in glsl. Lua uses 1 as index.
     local name = 'lights[' .. 0 .. ']'
-    shader:send(name .. '.position', light_active_creatures.position)
-    shader:send(name .. '.diffuse', light_active_creatures.diffuse)
-    shader:send(name .. '.power', light_active_creatures.power)
+    shader:send(name .. '.position', light_any_to_player_pov.position)
+    shader:send(name .. '.diffuse', light_any_to_player_pov.diffuse)
+    shader:send(name .. '.power', light_any_to_player_pov.power)
     -- Draw here with callback function.
     fun()
 
@@ -97,7 +98,7 @@ local multiple_lights = {
     { position = { 600, 600 }, diffuse = { 0.5, 0.3, 1 }, power = 64 },
 }
 local function shade_active_creatures_multiple_lights(fun, lights)
-    local shader = glsl_love_shaders.lighting_phong
+    local shader = glsl_shaders.lighting_phong
     LG.setShader(shader)
 
     lights = lights or multiple_lights
@@ -120,7 +121,7 @@ local function shade_active_creatures_multiple_lights(fun, lights)
 end
 
 local function shade_player_trail(fun)
-    local shader = glsl_love_shaders.lighting_phong
+    local shader = glsl_shaders.lighting_phong
     LG.setShader(shader)
 
     local cs = curr_state
@@ -143,7 +144,7 @@ end
 return {
     glsl_frag = glsl_frag,
 
-    shade_active_creatures_to_player_pov = shade_active_creatures_to_player_pov,
+    shade_any_to_player_pov = shade_any_to_player_pov,
     shade_active_creatures_multiple_lights = shade_active_creatures_multiple_lights,
     shade_player_trail = shade_player_trail,
 }

--- a/src/shaders/phong_lighting.lua
+++ b/src/shaders/phong_lighting.lua
@@ -46,9 +46,9 @@ vec4 effect(vec4 color,Image image,vec2 uvs,vec2 screen_coords){
 }
 ]]
 
-local LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR = { 0.5, 0.5, 0.5 } -- error.. shouldn't be triggered, as player action must always be defined
+local LIGHT_DEFAULT_ANY_TO_PLAYER_POV_DIFFUSE_COLOR = { 0.5, 0.5, 0.5 } -- error.. shouldn't be triggered, as player action must always be defined
 local LIGHT_DEFAULT_PLAYER_TRAIL_DIFFUSE_COLOR = { 0.5, 0.5, 0.5 } -- error.. shouldn't be triggered, as player action must always be defined
-local LIGHT_DIFFUSE_COLORS = common.PLAYER_ACTION_TO_DESATURATED_COLOR
+local LIGHT_DIFFUSE_COLORS = common.PLAYER_ACTION_TO_COLOR
 
 local light_active_creatures_screen_coords = { gw, gh }
 local light_player_trail_screen_coords = { gw, gh }
@@ -56,14 +56,14 @@ local light_player_trail_screen_coords = { gw, gh }
 --- @class (exact) Light
 local light_player_trail = {
     position = { 0, 0 },
-    diffuse = LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR,
+    diffuse = LIGHT_DEFAULT_ANY_TO_PLAYER_POV_DIFFUSE_COLOR,
     power = 32,
 }
 
 --- @class (exact) Light
 local light_any_to_player_pov = {
     position = { 0, 0 },
-    diffuse = LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR,
+    diffuse = LIGHT_DEFAULT_ANY_TO_PLAYER_POV_DIFFUSE_COLOR,
     power = 64,
 }
 
@@ -74,8 +74,9 @@ local function shade_any_to_player_pov(fun)
     local cs = curr_state
     light_active_creatures_screen_coords[1], light_active_creatures_screen_coords[2] = LG.getDimensions() -- shader:send('screen', { LG.getWidth(), LG.getHeight() })
     light_any_to_player_pov.position[1], light_any_to_player_pov.position[2] = cs.player_x, cs.player_y -- TODO: use func args
-    -- light_any_to_player_pov.diffuse = { 0.5, 0.5, 0.5 }
-    light_any_to_player_pov.diffuse = LIGHT_DIFFUSE_COLORS[player_action] or LIGHT_DEFAULT_ACTIVE_CREATURES_DIFFUSE_COLOR -- TODO: send color in func args
+    -- Avoid branching
+    -- light_any_to_player_pov.diffuse = LIGHT_DIFFUSE_COLORS[player_action] or LIGHT_DEFAULT_ANY_TO_PLAYER_POV_DIFFUSE_COLOR -- TODO: send color in func args
+    light_any_to_player_pov.diffuse = { 0.5, 0.5, 0.5 }
 
     shader:send('screen', light_active_creatures_screen_coords)
     shader:send('num_lights', 1)

--- a/src/timer.lua
+++ b/src/timer.lua
@@ -54,83 +54,83 @@ function M.update(dt)
     end
 end
 
-do -- TODO: TWEENING
-    -- Timer = {}
-    -- local timers = {}
-    -- -- Schedules a function to run after a delay (same as before)
-    -- function Timer.after(delay, func)
-    --     table.insert(timers, {timeLeft = delay, callback = func, isTween = false})
-    -- end
-    -- -- Adds a tween to change a value over a given duration
-    -- function Timer.tween(duration, subject, target, easing)
-    --     local startValues = {}
-    --     -- Store initial values for each target field
-    --     for key, targetValue in pairs(target) do
-    --         startValues[key] = subject[key]
-    --     end
-    --     local timer = {
-    --         timeLeft = duration,
-    --         duration = duration,
-    --         subject = subject,
-    --         target = target,
-    --         startValues = startValues,
-    --         easing = easing or function(t) return t end, -- Default to linear easing
-    --         isTween = true
-    --     }
-    --     table.insert(timers, timer)
-    -- end
-    --
-    -- -- Call this in your update loop to update timers and tweens
-    -- function Timer.update(dt)
-    --     for i = #timers, 1, -1 do
-    --         local timer = timers[i]
-    --         timer.timeLeft = timer.timeLeft - dt
-    --         if timer.isTween then
-    --             local progress = math.min(1, (timer.duration - timer.timeLeft) / timer.duration)
-    --             local easedProgress = timer.easing(progress)
-    --             -- Update each property in the subject towards the target value
-    --             for key, targetValue in pairs(timer.target) do
-    --                 local startValue = timer.startValues[key]
-    --                 timer.subject[key] = startValue + (targetValue - startValue) * easedProgress
-    --             end
-    --         end
-    --         if timer.timeLeft <= 0 then
-    --             if not timer.isTween then
-    --                 timer.callback(timer.callback) -- Call the function if it's not a tween
-    --             end
-    --             table.remove(timers, i)
-    --         end
-    --     end
-    -- end
-    -- -- Linear interpolation function (default easing)
-    -- function Timer.linear(t)
-    --     return t
-    -- end
-    -- -- Example easing function (ease out)
-    -- function Timer.easeOutQuad(t)
-    --     return 1 - (1 - t) * (1 - t)
-    -- end
-    -- return Timer
-    do -- TODO: Example of tweening
-        -- local Timer = require("timer")
-        -- local player = { x = 100, y = 100, alpha = 1 }
-        -- function love.update(dt)
-        --     Timer.update(dt)
-        -- end
-        -- function love.load()
-        --     -- Move player smoothly from x = 100 to x = 300 in 2 seconds
-        --     Timer.tween(2, player, { x = 300 }, Timer.easeOutQuad)
-        --     -- Fade out player (alpha = 1 to alpha = 0) in 3 seconds
-        --     Timer.tween(3, player, { alpha = 0 }, Timer.linear)
-        --     -- Example of a simple delay action
-        --     Timer.after(5, function() print("5 seconds passed!") end)
-        -- end
-        -- function love.draw()
-        --     -- Draw the player as a rectangle with a fading effect
-        --     love.graphics.setColor(1, 1, 1, player.alpha)
-        --     love.graphics.rectangle("fill", player.x, player.y, 50, 50)
-        -- end
-    end
-end
+-- do -- TODO: TWEENING
+--     -- Timer = {}
+--     -- local timers = {}
+--     -- -- Schedules a function to run after a delay (same as before)
+--     -- function Timer.after(delay, func)
+--     --     table.insert(timers, {timeLeft = delay, callback = func, isTween = false})
+--     -- end
+--     -- -- Adds a tween to change a value over a given duration
+--     -- function Timer.tween(duration, subject, target, easing)
+--     --     local startValues = {}
+--     --     -- Store initial values for each target field
+--     --     for key, targetValue in pairs(target) do
+--     --         startValues[key] = subject[key]
+--     --     end
+--     --     local timer = {
+--     --         timeLeft = duration,
+--     --         duration = duration,
+--     --         subject = subject,
+--     --         target = target,
+--     --         startValues = startValues,
+--     --         easing = easing or function(t) return t end, -- Default to linear easing
+--     --         isTween = true
+--     --     }
+--     --     table.insert(timers, timer)
+--     -- end
+--     --
+--     -- -- Call this in your update loop to update timers and tweens
+--     -- function Timer.update(dt)
+--     --     for i = #timers, 1, -1 do
+--     --         local timer = timers[i]
+--     --         timer.timeLeft = timer.timeLeft - dt
+--     --         if timer.isTween then
+--     --             local progress = math.min(1, (timer.duration - timer.timeLeft) / timer.duration)
+--     --             local easedProgress = timer.easing(progress)
+--     --             -- Update each property in the subject towards the target value
+--     --             for key, targetValue in pairs(timer.target) do
+--     --                 local startValue = timer.startValues[key]
+--     --                 timer.subject[key] = startValue + (targetValue - startValue) * easedProgress
+--     --             end
+--     --         end
+--     --         if timer.timeLeft <= 0 then
+--     --             if not timer.isTween then
+--     --                 timer.callback(timer.callback) -- Call the function if it's not a tween
+--     --             end
+--     --             table.remove(timers, i)
+--     --         end
+--     --     end
+--     -- end
+--     -- -- Linear interpolation function (default easing)
+--     -- function Timer.linear(t)
+--     --     return t
+--     -- end
+--     -- -- Example easing function (ease out)
+--     -- function Timer.easeOutQuad(t)
+--     --     return 1 - (1 - t) * (1 - t)
+--     -- end
+--     -- return Timer
+--     do -- TODO: Example of tweening
+--         -- local Timer = require("timer")
+--         -- local player = { x = 100, y = 100, alpha = 1 }
+--         -- function love.update(dt)
+--         --     Timer.update(dt)
+--         -- end
+--         -- function love.load()
+--         --     -- Move player smoothly from x = 100 to x = 300 in 2 seconds
+--         --     Timer.tween(2, player, { x = 300 }, Timer.easeOutQuad)
+--         --     -- Fade out player (alpha = 1 to alpha = 0) in 3 seconds
+--         --     Timer.tween(3, player, { alpha = 0 }, Timer.linear)
+--         --     -- Example of a simple delay action
+--         --     Timer.after(5, function() print("5 seconds passed!") end)
+--         -- end
+--         -- function love.draw()
+--         --     -- Draw the player as a rectangle with a fading effect
+--         --     love.graphics.setColor(1, 1, 1, player.alpha)
+--         --     love.graphics.rectangle("fill", player.x, player.y, 50, 50)
+--         -- end
+--     end
+-- end
 
 return M


### PR DESCRIPTION
## What's new

- Boosting does not hurt player if any intersection with creature entity.

## What's changed

- Reduce memory footprint by removing unused moonshine's background shader.
  - Also tweaked post-processing shader
- Add phong lighting based on player's POV (point of view).

## Commits

- **3b53cc6** - Avoid branching to get diffuse color while drawing player glow
- **d7d13d7** - Use vivid yellow while invulnerability timer is triggered in status bar
- **710f46c** - Allow player to perform pressure-like-sensitive boosting with smooth intensity control